### PR TITLE
Fix crash in KiCad 9.0

### DIFF
--- a/copper_thief.py
+++ b/copper_thief.py
@@ -178,9 +178,10 @@ class Dotter():
                     list([
                         ToMM(p.GetX()),
                         ToMM(p.GetY()),
-                        ToMM(max(p.GetDrillSizeX(),p.GetDrillSizeY()) / 2 + p.GetLocalClearance())
+                        ToMM(max(p.GetDrillSizeX(),p.GetDrillSizeY()) / 2 + (p.GetLocalClearance() or 0))
                     ])
                 )
+
         
         # Get the zone outline and deflate it so we don't put dots to close to the outside
         zone_outline = zone.Outline()


### PR DESCRIPTION
After installing `numpy` to KiCad's Python the plugin crashed with the following message:
<img width="536" height="350" alt="screenshot" src="https://github.com/user-attachments/assets/0febf8d4-0ae1-4bfc-b4f0-439b9d1059cf" />

For some reason (maybe due to change in KiCad/Pcbnew) `GetLocalClearance` returns `None` resulting in exception. By adding a default 0 when pad has no local clearance the plugin works as expected.